### PR TITLE
Fix PyGame README file links

### DIFF
--- a/notes/41 - PyGame/README.md
+++ b/notes/41 - PyGame/README.md
@@ -5,12 +5,12 @@ https://openbookproject.net/thinkcs/python/english3e/pygame.html
 
 Read the link above and then check out some of the following examples:
 
-[01. bare bones.py](01. bare bones.py) - A started file for PyGame that has all the bare essentials needed to create a pygame project.
+[01. bare bones.py](./01.%20bare%20bones.py) - A started file for PyGame that has all the bare essentials needed to create a pygame project.
 
-[02. colors.py](02. colors.py) -
+[02. colors.py](./02.%20colors.py) -
 
-[03. text.py](03. text.py) -
+[03. text.py](./03.%20text.py) -
 
-[04. fps.py](04. fps.py) -
+[04. fps.py](./04.%20fps.py) -
 
-[05. events.py](05. events.py) -
+[05. events.py](./05.%20events.py) -


### PR DESCRIPTION
The README.md links to the Python files did not work previously.

They used "` `" (spaces) rather than "`%20`", as well as other incorrect markdown link requirements.

They have been fixed in this pull request.